### PR TITLE
Update .gitignore check to use native Git matching pattern

### DIFF
--- a/fr.sh
+++ b/fr.sh
@@ -10,9 +10,9 @@ should_ignore() {
         return 0
     fi
     
-    # Check .gitignore
-    if grep -qE "^\b$base_item\b" .gitignore 2>/dev/null; then
-        return 0
+    # Use git check-ignore to ask Git whether the item is ignored
+    if git check-ignore -q "$item"; then
+        return 0  # The file/folder is ignored
     fi
     
     # Check .flattenignore


### PR DESCRIPTION
Using nextJS the default gitignore wasn't compatible with your checking method. 
This seems to work fine, and i think it is a good idea to use gits own logic (wildcards etc.) 
/node_modules didn't match with the folder otherwise.

I see there was already a pull-request for this, but i think this method is smoother